### PR TITLE
Adding of SPDefault.cnf.xml file

### DIFF
--- a/data/tftplist.txt
+++ b/data/tftplist.txt
@@ -55,6 +55,7 @@ s20d01b2_2.bin
 SEP000F34118045.cnf
 SEP001562EA69E8.cnf
 SEPDefault.cnf
+SPDefault.cnf.xml
 SIP000F34118045.cnf
 SIPinsertMAChere.cnf
 SIP000F34118045.cnf


### PR DESCRIPTION
File which contains LDAP credentials.

Related info:
http://c0d3xpl0it.blogspot.fr/2016/04/compromising-domain-admin-in-voip.html
https://www.exploit-db.com/exploits/30237/
